### PR TITLE
Memory optimisation on bezier curve computation

### DIFF
--- a/src/c/fctx.c
+++ b/src/c/fctx.c
@@ -645,6 +645,37 @@ static void bezier(FContext* fctx,
             fixed_t x2, fixed_t y2,
             fixed_t x3, fixed_t y3,
             fixed_t x4, fixed_t y4) {
+    {
+        int32_t da;
+
+        {
+            // Angle Condition
+            int32_t a23 = atan2_lookup((int16_t)((y3 - y2) / FIXED_POINT_SCALE),
+                                       (int16_t)((x3 - x2) / FIXED_POINT_SCALE));
+            da = abs(a23 - atan2_lookup((int16_t)((y2 - y1) / FIXED_POINT_SCALE),
+                                        (int16_t)((x2 - x1) / FIXED_POINT_SCALE)));
+
+            if (da >= TRIG_MAX_ANGLE) {
+                da = TRIG_MAX_ANGLE - da;
+            }
+
+            da += abs(atan2_lookup((int16_t)((y4 - y3) / FIXED_POINT_SCALE),
+                                   (int16_t)((x4 - x3) / FIXED_POINT_SCALE)) - a23);
+
+            if (da >= TRIG_MAX_ANGLE) {
+                da = TRIG_MAX_ANGLE - da;
+            }
+        }
+
+        if (da < MAX_ANGLE_TOLERANCE) {
+            // Finally we can stop the recursion
+            FPoint a = {x1, y1};
+            FPoint b = {x4, y4};
+            fctx_plot_edge(fctx, &a, &b);
+            return;
+        }
+    }
+
     fixed_t x12, y12;
     fixed_t x34, y34;
     fixed_t x123, y123;
@@ -667,36 +698,11 @@ static void bezier(FContext* fctx,
         y234  = (y23 + y34) / 2;
         x1234 = (x123 + x234) / 2;
         y1234 = (y123 + y234) / 2;
-
-        // Angle Condition
-        int32_t a23 = atan2_lookup((int16_t)((y3 - y2) / FIXED_POINT_SCALE),
-                                   (int16_t)((x3 - x2) / FIXED_POINT_SCALE));
-        int32_t da1 = abs(a23 - atan2_lookup((int16_t)((y2 - y1) / FIXED_POINT_SCALE),
-                                             (int16_t)((x2 - x1) / FIXED_POINT_SCALE)));
-        int32_t da2 = abs(atan2_lookup((int16_t)((y4 - y3) / FIXED_POINT_SCALE),
-                                       (int16_t)((x4 - x3) / FIXED_POINT_SCALE)) - a23);
-
-        if (da1 >= TRIG_MAX_ANGLE) {
-            da1 = TRIG_MAX_ANGLE - da1;
-        }
-
-        if (da2 >= TRIG_MAX_ANGLE) {
-            da2 = TRIG_MAX_ANGLE - da2;
-        }
-
-        if (da1 + da2 < MAX_ANGLE_TOLERANCE) {
-            // Finally we can stop the recursion
-            FPoint a = {x1, y1};
-            FPoint b = {x4, y4};
-            fctx_plot_edge(fctx, &a, &b);
-            return;
-        }
     }
 
     // Continue subdivision if points are being added successfully
     bezier(fctx, x1, y1, x12, y12, x123, y123, x1234, y1234);
     bezier(fctx, x1234, y1234, x234, y234, x34, y34, x4, y4);
-
 }
 
 void fctx_move_to_func(FContext* fctx, FPoint* params) {


### PR DESCRIPTION
Remove unneeded local variable from stack before calling bezier recursive function.